### PR TITLE
Runme.io will be closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 # cmcapi
 CMCAPI v1.0 : CoinMarketCapAPI Wrapper
-[![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=720d5157-41cd-4aea-8a4e-9cca18ea62c4)


### PR DESCRIPTION
Dear partners, due to the next step in Runme service evolution we would need to close access to service from 01.12.2020. With this, we kindly ask you to remove the Runme button from Readme.md before this date.